### PR TITLE
When serializing an Hash, check present of the key before trying string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Your contribution
+* When serializing an Hash, check present of the key before trying string ([#57](https://github.com/petalmd/bright_serializer/pull/57))
 
 ## 0.2.4 (2021-02-19)
 

--- a/lib/bright_serializer/attribute.rb
+++ b/lib/bright_serializer/attribute.rb
@@ -21,7 +21,7 @@ module BrightSerializer
         if @block
           @block.arity.abs == 1 ? object.instance_eval(&@block) : object.instance_exec(object, params, &@block)
         elsif object.is_a?(Hash)
-          object[key] || object[key.to_s]
+          object.key?(key) ? object[key] : object[key.to_s]
         else
           object.send(key)
         end

--- a/spec/lib/bright_serializer/attribute_spec.rb
+++ b/spec/lib/bright_serializer/attribute_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../../share/user'
+
+RSpec.describe BrightSerializer::Attribute do
+  let(:object_to_serialize) { { first_name: Faker::Name.first_name, is_admin: false } }
+
+  describe '#serialize' do
+    context 'when object is an hash' do
+      shared_examples 'serializing_hash' do
+        it 'return the value' do
+          object_to_serialize.each_key do |key|
+            instance = described_class.new(key.to_sym, nil, nil)
+            expect(instance.serialize(object_to_serialize, {})).to eq object_to_serialize[key]
+          end
+        end
+      end
+
+      context 'when keys are symbol' do
+        it_behaves_like 'serializing_hash'
+      end
+
+      context 'when keys are string' do
+        let(:object_to_serialize) { { 'first_name' => Faker::Name.first_name, 'is_admin' => false } }
+
+        it_behaves_like 'serializing_hash'
+      end
+    end
+
+    context 'when object is an object' do
+      let(:object_to_serialize) do
+        User.new.tap { |user| allow(user).to receive(:is_admin).and_return(false) }
+      end
+
+      it 'return the value' do
+        %i[first_name last_name is_admin].each do |attribute|
+          instance = described_class.new(attribute, nil, nil)
+          expect(instance.serialize(object_to_serialize, {})).to eq object_to_serialize.send(attribute)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix regression introduced by #54