### PR TITLE
Fixes #84 Added the support to use instance methods from a serializer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## master (unreleased)
 
-* Your contribution
-* Use real coveralls_reborn gem 
+* Added the support to use instance methods from a serializer class in the library
+* Use real coveralls_reborn gem
 
 ## 0.2.5 (2021-03-08)
 
@@ -34,7 +34,7 @@
 * Define entity in serializer for grape_swagger ([#9](https://github.com/petalmd/bright_serializer/pull/9))
 
 ## 0.1.1 (2020-07-13)
- 
+
 * Add description in gemspec file
 * Add content in CHANGELOG.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-* Added the support to use instance methods from a serializer class in the library
+* Added the support to use instance methods from a serializer class in the library ([#85](https://github.com/petalmd/bright_serializer/pull/85))
 * Use real coveralls_reborn gem
 
 ## 0.2.5 (2021-03-08)

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Create a class and include `BrightSerializer::Serializer`
 class AccountSerializer
   include BrightSerializer::Serializer
   attributes :id, :first_name, :last_name
-  
+
   # With a block
   attribute :name do |object|
     "#{object.first_name} #{object.last_name}"
   end
-  
+
   # With a block shorter
   attribute :created_at, &:to_s
 end
@@ -54,7 +54,7 @@ You can pass params to your serializer. For example to have more context with th
 class AccountSerializer
   include BrightSerializer::Serializer
   attributes :id, :first_name, :last_name
-  
+
   attribute :friend do |object, params|
     object.is_friend_with? params[:current_user]
   end
@@ -66,14 +66,14 @@ AccountSerializer.new(Account.first, params: { current_user: current_user }).to_
 
 ### Conditional Attributes
 
-Attribute can be remove from serialization by passing a `proc` to the option `if`. If the proc return `true` the attibute 
- will be serialize. `object` and `params` or accessible. 
+Attribute can be remove from serialization by passing a `proc` to the option `if`. If the proc return `true` the attibute
+ will be serialize. `object` and `params` or accessible.
 
 ```ruby
 class AccountSerializer
   include BrightSerializer::Serializer
   attributes :id, :first_name, :last_name
-  
+
   attribute :email, if: -> { |object, params| params[:current_user].is_admin? }
 end
 ```
@@ -119,7 +119,7 @@ end
 class AccountSerializer
   include BrightSerializer::Serializer
   attributes :id, :first_name, :last_name
-  
+
   attribute :friends do |object|
     FriendSerializer.new(object.friends)
   end
@@ -129,7 +129,7 @@ end
 ### Entity
 
 You can define the entity of your serializer to generate documentation with the option `entity`.
-The feature was build to work with [grape-swagger](https://github.com/ruby-grape/grape-swagger). 
+The feature was build to work with [grape-swagger](https://github.com/ruby-grape/grape-swagger).
 For more information about defining a model entity see the [Swagger documentation](https://swagger.io/specification/v2/?sbsearch=array%20response#schema-object).
 
 ```ruby
@@ -139,10 +139,29 @@ class AccountSerializer
   attribute :name
 
   attribute :friends,
-    entity: { 
+    entity: {
       type: :array, items: { ref: 'FriendSerializer' }, description: 'The list the account friends.'
      } do |object|
     FriendSerializer.new(object.friends)
+  end
+end
+```
+
+### Instance
+
+If you have defined instance methods inside your serializer you can access them inside block attribute.
+
+```ruby
+class AccountSerializer
+  include BrightSerializer::Serializer
+  attributes [:id, :name]
+
+  attribute :print do |object|
+    print_account(object)
+  end
+
+  def print_account(object)
+    "Account: #{object.name}"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you have defined instance methods inside your serializer you can access them 
 ```ruby
 class AccountSerializer
   include BrightSerializer::Serializer
-  attributes [:id, :name]
+  attributes :id, :name
 
   attribute :print do |object|
     print_account(object)

--- a/lib/bright_serializer/attribute.rb
+++ b/lib/bright_serializer/attribute.rb
@@ -14,12 +14,16 @@ module BrightSerializer
       @entity = entity ? Entity::Base.new(entity) : nil
     end
 
-    def serialize(object, params)
+    def serialize(serializer_instance, object, params)
       return unless object
 
       value =
         if @block
-          @block.arity.abs == 1 ? object.instance_eval(&@block) : object.instance_exec(object, params, &@block)
+          if @block.arity.abs == 1
+            serializer_instance.instance_exec(object, &@block)
+          else
+            serializer_instance.instance_exec(object, params, &@block)
+          end
         elsif object.is_a?(Hash)
           object.key?(key) ? object[key] : object[key.to_s]
         else

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -28,7 +28,7 @@ module BrightSerializer
         next if @fields.any? && !@fields.include?(attribute.key)
         next unless attribute.condition?(object, @params)
 
-        result[attribute.transformed_key] = attribute.serialize(object, @params)
+        result[attribute.transformed_key] = attribute.serialize(self, object, @params)
       end
     end
 

--- a/spec/lib/bright_serializer/attribute_spec.rb
+++ b/spec/lib/bright_serializer/attribute_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BrightSerializer::Attribute do
         it 'return the value' do
           object_to_serialize.each_key do |key|
             instance = described_class.new(key.to_sym, nil, nil)
-            expect(instance.serialize(object_to_serialize, {})).to eq object_to_serialize[key]
+            expect(instance.serialize(instance, object_to_serialize, {})).to eq object_to_serialize[key]
           end
         end
       end
@@ -35,7 +35,7 @@ RSpec.describe BrightSerializer::Attribute do
       it 'return the value' do
         %i[first_name last_name is_admin].each do |attribute|
           instance = described_class.new(attribute, nil, nil)
-          expect(instance.serialize(object_to_serialize, {})).to eq object_to_serialize.send(attribute)
+          expect(instance.serialize(instance, object_to_serialize, {})).to eq object_to_serialize.send(attribute)
         end
       end
     end

--- a/spec/lib/bright_serializer/serializer_params_spec.rb
+++ b/spec/lib/bright_serializer/serializer_params_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe BrightSerializer::Serializer do
         attribute :params do |object, params|
           "#{object.first_name} #{object.last_name} #{params}"
         end
+
+        attribute :params_upcase do |object, params|
+          upcase(object, params)
+        end
+
+        def upcase(object, params)
+          "#{object.first_name} #{object.last_name} #{params}".upcase
+        end
       end
     end
 
@@ -27,7 +35,8 @@ RSpec.describe BrightSerializer::Serializer do
         first_name: user.first_name,
         last_name: user.last_name,
         name: "#{user.first_name} #{user.last_name}",
-        params: "#{user.first_name} #{user.last_name} #{param}"
+        params: "#{user.first_name} #{user.last_name} #{param}",
+        params_upcase: "#{user.first_name} #{user.last_name} #{param}".upcase
       }
     end
 

--- a/spec/lib/bright_serializer/serializer_spec.rb
+++ b/spec/lib/bright_serializer/serializer_spec.rb
@@ -11,7 +11,14 @@ RSpec.describe BrightSerializer::Serializer do
         attribute :name do |object|
           "#{object.first_name} #{object.last_name}"
         end
+        attribute :name_to_s do |object|
+          add_mr(object)
+        end
         attribute :first, &:first_name
+
+        def add_mr(object)
+          "User: #{object.first_name} #{object.last_name}"
+        end
       end
     end
 
@@ -23,6 +30,7 @@ RSpec.describe BrightSerializer::Serializer do
         first_name: user.first_name,
         last_name: user.last_name,
         name: "#{user.first_name} #{user.last_name}",
+        name_to_s: "User: #{user.first_name} #{user.last_name}",
         first: user.first_name
       }
     end


### PR DESCRIPTION
In FastJsonApi serializer we were able to use instance method inside block attribute and this is a nice to have so added the support for that.

Modified:

1. Change logs.
2. README to add an example with the new parameter available.
3. Unit test to test the new feature.