### PR TITLE
Call callable if respond to for entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Allow to evaluate entity values with a callable lambda. ([#88](https://github.com/petalmd/bright_serializer/pull/88))
 * Fix `FrozenError (can't modify frozen Array)` when parsing entity. ([#83](https://github.com/petalmd/bright_serializer/pull/83))
 * Added the support to use instance methods from a serializer class in the library ([#85](https://github.com/petalmd/bright_serializer/pull/85))
 * Use real coveralls_reborn gem

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ class AccountSerializer
     FriendSerializer.new(object.friends)
   end
 end
+
+```
+Callable values are supported.
+
+```ruby
+{ entity: { type: :string, enum: -> { SomeModel::ENUMVALUES } } }
 ```
 
 ### Instance

--- a/lib/bright_serializer/entity/base.rb
+++ b/lib/bright_serializer/entity/base.rb
@@ -16,6 +16,7 @@ module BrightSerializer
       def to_h
         @definition = Inflector.deep_transform_keys_in_object(@definition) { |k| Inflector.camel_lower k.to_s }
         parse_ref!
+        evaluate_callable!
         @definition
       end
 
@@ -26,6 +27,12 @@ module BrightSerializer
         ref_entity_name = Inflector.constantize(object.delete('ref')).entity_name
         relation = "#/definitions/#{ref_entity_name}"
         object['$ref'] = relation
+      end
+
+      def evaluate_callable!
+        @definition = Inflector.deep_transform_values_in_object(@definition) do |value|
+          value.respond_to?(:call) ? value.call : value
+        end
       end
 
       def nested_hash(obj, key)

--- a/lib/bright_serializer/inflector.rb
+++ b/lib/bright_serializer/inflector.rb
@@ -73,5 +73,17 @@ class Inflector
         object
       end
     end
+
+    # File active_support/core_ext/hash/deep_transform_values.rb, line 25
+    def deep_transform_values_in_object(object, &block)
+      case object
+      when Hash
+        object.transform_values { |value| deep_transform_values_in_object(value, &block) }
+      when Array
+        object.map { |e| deep_transform_values_in_object(e, &block) }
+      else
+        yield(object)
+      end
+    end
   end
 end

--- a/spec/lib/bright_serializer/entity/base_spec.rb
+++ b/spec/lib/bright_serializer/entity/base_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe BrightSerializer::Entity::Base do
         expect(subject).to eq(['type' => :string])
       end
     end
+
+    context 'when passing a callable object as value' do
+      let(:instance) { described_class.new(type: :string, enum: -> { [1, 2] }) }
+
+      it 'return the definition' do
+        expect(subject).to eq('type' => :string, 'enum' => [1, 2])
+      end
+    end
   end
 
   describe '#parser_ref!' do

--- a/spec/lib/bright_serializer/inflector_spec.rb
+++ b/spec/lib/bright_serializer/inflector_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe Inflector do
 
     specify { is_expected.to eq described_class }
   end
+
+  describe '#deep_transform_values_in_object' do
+    subject { described_class.deep_transform_values_in_object(hash, &:capitalize) }
+
+    let(:hash) { { users: [{ name: 'john' }] } }
+
+    it 'transforms value' do
+      expect(subject).to eq({ users: [{ name: 'John' }] })
+    end
+  end
 end


### PR DESCRIPTION
Fix #81 

Allow to evaluate value in a callable lamda, in entity definition.

```ruby
attribute :category, entity: { type: :string, enum:  -> { ::Appointment.categories.keys } }
```
