### PR TITLE
Perfo Use nil instead of empty set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-* Move specs out of lib ([#96](https://github.com/petalmd/bright_serializer/pull/96)) 
+* Performance improvements, use nil instead of empty set. ([#97](https://github.com/petalmd/bright_serializer/pull/97))
+* Move specs out of lib. ([#96](https://github.com/petalmd/bright_serializer/pull/96))
 
 ## 0.3.0 (2022-05-26)
 

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -20,12 +20,14 @@ module BrightSerializer
     def initialize(object, **options)
       @object = object
       @params = options.delete(:params)
-      @fields = Set.new(options.delete(:fields))
+
+      fields = options.delete(:fields)
+      @fields = fields ? Set.new(fields) : nil
     end
 
     def serialize(object)
       self.class.attributes_to_serialize.each_with_object({}) do |attribute, result|
-        next if @fields.any? && !@fields.include?(attribute.key)
+        next if !@fields.nil? && !@fields.include?(attribute.key)
         next unless attribute.condition?(object, @params)
 
         result[attribute.transformed_key] = attribute.serialize(self, object, @params)


### PR DESCRIPTION
My benchmark

```ruby
require_relative 'lib/bright_serializer'
require 'benchmark/ips'

class User
  attr_reader :id, :first_name, :last_name
  def initialize(id, first_name, last_name)
    @id = id
    @first_name = first_name
    @last_name = last_name
  end
end

class S
  include BrightSerializer::Serializer
  attribute :id, :first_name, :last_name
  attribute do |object|
    "#{object.first_name} #{object.last_name}"
  end
end

users = 200.times.map { |i| User.new(i, "first_name_#{i}", "last_name_#{i}") }

Benchmark.ips do |x|
  x.report('A') do
    S.new(users).to_json
  end
end

# Before
# Warming up --------------------------------------
#                    A    68.000  i/100ms
# Calculating -------------------------------------
#                    A    681.581  (± 1.3%) i/s -      3.468k in   5.089176s
# After
# Warming up --------------------------------------
#                    A   121.000  i/100ms
# Calculating -------------------------------------
#                    A      1.191k (± 1.1%) i/s -      6.050k in   5.078418s
# 1.74x faster
```

<img width="740" alt="Screen Shot 2022-09-26 at 20 23 49" src="https://user-images.githubusercontent.com/7858787/192403822-818b008c-6f2a-4554-942e-5788e90b0b23.png">
