### PR TITLE
Performance improvements, calculate attributes to serialize only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Performance improvements, calculate attributes to serialize only once. ([#98](https://github.com/petalmd/bright_serializer/pull/98))
 * Add instrumentation. ([#90](https://github.com/petalmd/bright_serializer/pull/90))
 
 ## 0.3.1 (2022-09-28)

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -71,7 +71,7 @@ module BrightSerializer
 
       def set_key_transform(transform_name) # rubocop:disable Naming/AccessorMethodName
         unless SUPPORTED_TRANSFORMATION.include?(transform_name)
-          raise ArgumentError "Invalid transformation: #{SUPPORTED_TRANSFORMATION}"
+          raise ArgumentError, "Invalid transformation: #{SUPPORTED_TRANSFORMATION}"
         end
 
         @transform_method = transform_name

--- a/spec/bright_serializer/serializer_spec.rb
+++ b/spec/bright_serializer/serializer_spec.rb
@@ -44,20 +44,23 @@ RSpec.describe BrightSerializer::Serializer do
     end
 
     context 'when multiple element to serialize' do
-      let(:users) { [User.new, User.new] }
+      let(:users) { p [User.new, User.new] }
+      let(:user) { users }
 
       let(:result) do
         users.map do |user|
           {
             first_name: user.first_name,
             last_name: user.last_name,
-            name: "#{user.first_name} #{user.last_name}"
+            name: "#{user.first_name} #{user.last_name}",
+            name_to_s: "User: #{user.first_name} #{user.last_name}",
+            first: user.first_name
           }
         end
+      end
 
-        it 'serialize an array of hash' do
-          expect(instance.to_hash).to eq(result)
-        end
+      it 'serialize an array of hash' do
+        expect(instance.to_hash).to eq(result)
       end
     end
 

--- a/spec/bright_serializer/serializer_spec.rb
+++ b/spec/bright_serializer/serializer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe BrightSerializer::Serializer do
     end
 
     context 'when multiple element to serialize' do
-      let(:users) { p [User.new, User.new] }
+      let(:users) { [User.new, User.new] }
       let(:user) { users }
 
       let(:result) do

--- a/spec/bright_serializer/serializer_transform_key_spec.rb
+++ b/spec/bright_serializer/serializer_transform_key_spec.rb
@@ -116,4 +116,16 @@ RSpec.describe BrightSerializer::Serializer do
       expect(instance.to_hash).to eq(result)
     end
   end
+
+  describe 'not supported transformation' do
+    it 'will raise an error' do
+      expect do
+        Class.new do
+          include BrightSerializer::Serializer
+
+          set_key_transform :unknown
+        end
+      end.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
1.1704x faster

<details>
<summary>Benchmark</summary>

```ruby
require_relative './lib/bright_serializer'

class User
  attr_accessor :friends, :id, :first_name, :last_name
  def initialize(id, first_name, last_name)
    @id = id
    @first_name = first_name
    @last_name = last_name
  end
end

class UserSerializer
  include BrightSerializer::Serializer
  attributes :id, :first_name, :last_name

  attribute :friends do |object|
    UserSerializer.new(object.friends, fields: [:id, :first_name])
  end
end


list = 100.times.map { |i| User.new(i, "first_name_#{i}", "last_name_#{i}") }
list.each do |user|
  user.friends = list.sample(10).map { |u| nu = u.dup; nu.friends = nil; nu }
end

require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('A') do
    UserSerializer.new(list).to_hash
  end
  x.compare!
end

# A      1.104k (± 1.4%) i/s -      5.618k in   5.089321s
# A    959.739  (± 1.6%) i/s -      4.800k in   5.002612s
# 1.1704x faster
```

</details>

---

Fix and add specs for coverage