### PR TITLE
Return to previous serialize nil behaviour

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,6 @@ Metrics/ParameterLists:
 
 RSpec/NestedGroups:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* Return to previous behaviour from `v0.4.X` (revert of [#105](https://github.com/petalmd/bright_serializer/pull/105)).
+    Add deprecation warn and class setting to use future behaviour. ([#X](https://github.com/petalmd/bright_serializer/pull/X))
+
 ## 0.5.1 (2024-04-05)
 
 * Better handle of ActiveSupport::Notifications defined? ([#111](https://github.com/petalmd/bright_serializer/pull/111))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 * Return to previous behaviour from `v0.4.X` (revert of [#105](https://github.com/petalmd/bright_serializer/pull/105)).
-    Add deprecation warn and class setting to use future behaviour. ([#X](https://github.com/petalmd/bright_serializer/pull/X))
+    Add deprecation warn and class setting to use future behaviour. ([#112](https://github.com/petalmd/bright_serializer/pull/112))
 
 ## 0.5.1 (2024-04-05)
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 
 #### Serializing nil ([#103](https://github.com/petalmd/bright_serializer/issues/103))
 
-In version `v0.6.X` passing `nil` will raise a warning and still continue to all attributes with nil. 
+In version `v0.6.X` passing `nil` will raise a warning and still continue to return all attributes with nil. 
 
 ```ruby
 MySerializer.new(nil).to_hash # => { id: nil, name: nil }

--- a/README.md
+++ b/README.md
@@ -205,6 +205,28 @@ class AccountSerializer
 end
 ```
 
+### Deprecations
+
+#### Serializing nil ([#103](https://github.com/petalmd/bright_serializer/issues/103))
+
+In version `v0.6.X` passing `nil` will raise a warning, and continue to serialize with the previous behavior. 
+
+```ruby
+MySerializer.new(nil).to_hash # => { id: nil, name: nil }
+```
+
+To use the future default behavior (`v0.7.X`), you can use the class option `serialize_nil_if_nil`.
+
+```ruby
+class MySerializer
+  include BrightSerializer::Serializer
+  serialize_nil_if_nil
+  # ...
+end
+
+MySerializer.new(nil).to_hash # => nil
+```
+
 ## Benchmark
 
 Event if the main goal is not performance, it has very good result.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 
 #### Serializing nil ([#103](https://github.com/petalmd/bright_serializer/issues/103))
 
-In version `v0.6.X` passing `nil` will raise a warning, and continue to serialize with the previous behavior. 
+In version `v0.6.X` passing `nil` will raise a warning and still continue to all attributes with nil. 
 
 ```ruby
 MySerializer.new(nil).to_hash # => { id: nil, name: nil }

--- a/lib/bright_serializer/deprecation.rb
+++ b/lib/bright_serializer/deprecation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'active_support/deprecation'
+
+module BrightSerializer
+  class Deprecation
+    DEPRECATION_INSTANCE = ActiveSupport::Deprecation.new('0.7.0', 'BrightSerializer')
+    private_constant :DEPRECATION_INSTANCE
+    DEPRECATION_MESSAGE = 'BrightSerializer: Serializing `nil` will stop returning ' \
+                  "a JSON with all attributes and null values.\n" \
+                  "To use the new behaviour use the class level setting `serialize_nil_if_nil`.\n" \
+                  "To keep the old behaviour using an empty hash may work: `MySerializer.new(object || { }).to_json`.\n" \
+                  "See: https://github.com/petalmd/bright_serializer/issues/103 for more details about this change.\n"
+    private_constant :DEPRECATION_MESSAGE
+
+    def self.warn
+      DEPRECATION_INSTANCE.warn(DEPRECATION_MESSAGE)
+    end
+  end
+end

--- a/lib/bright_serializer/deprecation.rb
+++ b/lib/bright_serializer/deprecation.rb
@@ -3,9 +3,7 @@
 require 'active_support/deprecation'
 
 module BrightSerializer
-  class Deprecation
-    DEPRECATION_INSTANCE = ActiveSupport::Deprecation.new('0.7.0', 'BrightSerializer')
-    private_constant :DEPRECATION_INSTANCE
+  class Deprecation < ActiveSupport::Deprecation
     DEPRECATION_MESSAGE = 'BrightSerializer: Serializing `nil` will stop returning ' \
                           "a JSON with all attributes and null values.\n" \
                           "To use the new behaviour use the class level setting `serialize_nil_if_nil`.\n" \
@@ -15,8 +13,12 @@ module BrightSerializer
                           "for more details about this change.\n"
     private_constant :DEPRECATION_MESSAGE
 
-    def self.warn
-      DEPRECATION_INSTANCE.warn(DEPRECATION_MESSAGE)
+    def initialize
+      super('0.7.0', 'BrightSerializer')
+    end
+
+    def self.warn(klass)
+      instance.warn(DEPRECATION_MESSAGE + "Called from `#{klass}`.\n")
     end
   end
 end

--- a/lib/bright_serializer/deprecation.rb
+++ b/lib/bright_serializer/deprecation.rb
@@ -18,7 +18,7 @@ module BrightSerializer
     end
 
     def self.warn(klass)
-      instance.warn(DEPRECATION_MESSAGE + "Called from `#{klass}`.\n")
+      super(DEPRECATION_MESSAGE + "Called from `#{klass}`.\n")
     end
   end
 end

--- a/lib/bright_serializer/deprecation.rb
+++ b/lib/bright_serializer/deprecation.rb
@@ -7,10 +7,12 @@ module BrightSerializer
     DEPRECATION_INSTANCE = ActiveSupport::Deprecation.new('0.7.0', 'BrightSerializer')
     private_constant :DEPRECATION_INSTANCE
     DEPRECATION_MESSAGE = 'BrightSerializer: Serializing `nil` will stop returning ' \
-                  "a JSON with all attributes and null values.\n" \
-                  "To use the new behaviour use the class level setting `serialize_nil_if_nil`.\n" \
-                  "To keep the old behaviour using an empty hash may work: `MySerializer.new(object || { }).to_json`.\n" \
-                  "See: https://github.com/petalmd/bright_serializer/issues/103 for more details about this change.\n"
+                          "a JSON with all attributes and null values.\n" \
+                          "To use the new behaviour use the class level setting `serialize_nil_if_nil`.\n" \
+                          'To keep the old behaviour using an empty hash may work: ' \
+                          "`MySerializer.new(object || { }).to_json`.\n" \
+                          'See: https://github.com/petalmd/bright_serializer/issues/103 ' \
+                          "for more details about this change.\n"
     private_constant :DEPRECATION_MESSAGE
 
     def self.warn

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -31,7 +31,7 @@ module BrightSerializer
       if @object.nil?
         return nil if self.class.serialize_nil
 
-        Deprecation.warn
+        Deprecation.warn(self.class)
       end
 
       attributes_to_serialize.each_with_object({}) do |attribute, result|

--- a/spec/bright_serializer/serializer_spec.rb
+++ b/spec/bright_serializer/serializer_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe BrightSerializer::Serializer do
           {
             first_name: user.first_name,
             last_name: user.last_name,
-            friends: {:first_name=>nil, :last_name=>nil}
+            friends: { first_name: nil, last_name: nil }
           }
         end
 


### PR DESCRIPTION
We need the change from #107 to fix warning in Ruby 2.7.
But the be the big breaking change from #103 comes alongs and there is no middle version to mark it as deprecation.

With the PR, there is a new Deprecation from BrightSerializer and a option to up-in the future behaviour. See readme change in the PR for more details. 

Deprecation message:

```
irb(main):002:0> BrightSerializer::Deprecation.warn
DEPRECATION WARNING: BrightSerializer: Serializing `nil` will stop returning a JSON with all attributes and null values.
To use the new behaviour use the class level setting `serialize_nil_if_nil`.
To keep the old behaviour using an empty hash may work: `MySerializer.new(object || { }).to_json`.
See: https://github.com/petalmd/bright_serializer/issues/103 for more details about this change.
 (called from irb_binding at (irb):2)
```