### PR TITLE
Handle nil in array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Handle nil in array ([#113](https://github.com/petalmd/bright_serializer/pull/113))
+
 ## 0.5.1 (2024-04-05)
 
 * Better handle of ActiveSupport::Notifications defined? ([#111](https://github.com/petalmd/bright_serializer/pull/111))

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -27,7 +27,7 @@ module BrightSerializer
     end
 
     def serialize(object, attributes_to_serialize)
-      return nil if @object.nil?
+      return nil if object.nil?
 
       attributes_to_serialize.each_with_object({}) do |attribute, result|
         next unless attribute.condition?(object, @params)

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -27,7 +27,7 @@ module BrightSerializer
     end
 
     def serialize(object, attributes_to_serialize)
-      return nil if object.nil?
+      return if object.nil?
 
       attributes_to_serialize.each_with_object({}) do |attribute, result|
         next unless attribute.condition?(object, @params)

--- a/spec/bright_serializer/serializer_spec.rb
+++ b/spec/bright_serializer/serializer_spec.rb
@@ -71,6 +71,27 @@ RSpec.describe BrightSerializer::Serializer do
       it 'serialize an array of hash' do
         expect(instance.to_hash).to eq(result)
       end
+
+      context 'when an element is nil' do
+        let(:users) { [User.new, nil] }
+        let(:result) do
+          user = users.first
+          [
+            {
+              first_name: user.first_name,
+              last_name: user.last_name,
+              name: "#{user.first_name} #{user.last_name}",
+              name_to_s: "User: #{user.first_name} #{user.last_name}",
+              first: user.first_name
+            },
+            nil
+          ]
+        end
+
+        it 'serialize an array of hash' do
+          expect(instance.to_hash).to eq(result)
+        end
+      end
     end
 
     context 'when embedded serializer' do


### PR DESCRIPTION
Currently in main branch:

```ruby
class Account2
  attr_accessor :id, :name

  def initialize(id, name)
    @id = id
    @name = name
  end
  
  def read_attribute_for_serialization(name)
    send(name)
  end
end

class AccountSerializer
  include BrightSerializer::Serializer
  attributes :id, :name
end

class AMSAccountSerializer < ActiveModel::Serializer
  attributes :id, :name
end

a = [
  Account2.new(1, 'foo'),
  nil,
  Account2.new(2, 'bar')
]

pp AccountSerializer.new(a).serializable_hash
# [{:id=>1, :name=>"foo"}, {:id=>nil, :name=>nil}, {:id=>2, :name=>"bar"}]
pp ActiveModel::ArraySerializer.new(a, each_serializer: AMSAccountSerializer).serializable_array
# [{:id=>1, :name=>"foo"}, nil, {:id=>2, :name=>"bar"}]
```

There is a diff when serializing nil.

I added a specs to be sure of the behaviour mimic the AMS.