### PR TITLE
Conditional block executed in the context of serializer method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Conditional block executed in the context of serializer ([#119](https://github.com/petalmd/bright_serializer/pull/119))
+
 ## 0.5.2 (2023-09-19)
 
 * Handle nil in array ([#113](https://github.com/petalmd/bright_serializer/pull/113))

--- a/lib/bright_serializer/attribute.rb
+++ b/lib/bright_serializer/attribute.rb
@@ -22,10 +22,10 @@ module BrightSerializer
       value.respond_to?(:serializable_hash) ? value.serializable_hash : value
     end
 
-    def condition?(object, params)
+    def condition?(serializer_instance, object, params)
       return true unless @condition
 
-      @condition.call(object, params)
+      serializer_instance.instance_exec(object, params, &@condition)
     end
 
     private

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -73,7 +73,7 @@ module BrightSerializer
 
       alias attribute attributes
 
-      def has_one(key, serializer:, **options, &block) # rubocop:disable Naming/PredicateName
+      def has_one(key, serializer:, **options, &block) # rubocop:disable Naming/PredicatePrefix
         attribute = AttributeRelation.new(
           key, serializer, options.delete(:if), options.delete(:entity), options, &block
         )

--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -30,7 +30,7 @@ module BrightSerializer
       return if object.nil?
 
       attributes_to_serialize.each_with_object({}) do |attribute, result|
-        next unless attribute.condition?(object, @params)
+        next unless attribute.condition?(self, object, @params)
 
         result[attribute.transformed_key] = attribute.serialize(self, object, @params)
       end

--- a/spec/bright_serializer/serializer_condition_spec.rb
+++ b/spec/bright_serializer/serializer_condition_spec.rb
@@ -44,5 +44,26 @@ RSpec.describe BrightSerializer::Serializer do
         expect(instance.to_hash).to eq(result)
       end
     end
+
+    context 'when condition use instance method' do
+      let(:serializer_class) do
+        Class.new do
+          include BrightSerializer::Serializer
+          attributes :first_name, :last_name
+          attribute :name, if: proc { |_object| add_name? } do |object|
+            "#{object.first_name} #{object.last_name}"
+          end
+
+          def add_name?
+            false
+          end
+        end
+      end
+      let(:instance) { serializer_class.new(user, params: 0) }
+
+      it 'serialize without name' do
+        expect(instance.to_hash).to eq(result)
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow the proc passed to the conditional option to call an instance method of the serializer.

```ruby
class UserSerializer
  include BrightSerializer::Serializer
  
  attributes :first_name, :last_name
  attribute :name, if: proc { |_object| add_name? } do |object|
    "#{object.first_name} #{object.last_name}"
  end

  def add_name?
    false
  end
end
```

Before the `add_name?` in the proc could not use the `add_name?` defined in the serializer.

With this change it can.
  