### PR TITLE
Params, if not passed, it is an empty Hash

### DIFF
--- a/lib/bright_serializer/serializer.rb
+++ b/lib/bright_serializer/serializer.rb
@@ -22,7 +22,7 @@ module BrightSerializer
 
     def initialize(object, **options)
       @object = object
-      @params = options.delete(:params)
+      @params = options.delete(:params) || {}
       @fields = options.delete(:fields)
     end
 

--- a/spec/bright_serializer/serializer_params_spec.rb
+++ b/spec/bright_serializer/serializer_params_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BrightSerializer::Serializer do
           "#{object.first_name} #{object.last_name}"
         end
         attribute :params do |object, params|
-          "#{object.first_name} #{object.last_name} #{params}"
+          "#{object.first_name} #{object.last_name} #{params[:suffix]}"
         end
 
         attribute :params_upcase do |object, params|
@@ -23,12 +23,12 @@ RSpec.describe BrightSerializer::Serializer do
         end
 
         def upcase(object, params)
-          "#{object.first_name} #{object.last_name} #{params}".upcase
+          "#{object.first_name} #{object.last_name} #{params[:suffix]}".upcase
         end
       end
     end
 
-    let(:instance) { serializer_class.new(user, params: param) }
+    let(:instance) { serializer_class.new(user, params: { suffix: param }) }
 
     let(:param) { Faker::Lorem.word }
     let(:result) do
@@ -43,6 +43,22 @@ RSpec.describe BrightSerializer::Serializer do
 
     it 'serialize params' do
       expect(instance.to_hash).to eq(result)
+    end
+
+    context 'when not passing params' do
+      # The anonymous serializer use params in a way that it take for granted that params is always a hash
+      # and call params[:suffix], so if params is nil it will raise an error
+      # This test ensure that when params is not passed it will be an empty hash and no error is raised.
+      it 'passes an empty hash' do
+        instance = serializer_class.new(user)
+        expect(instance.to_hash).to eq(
+          first_name: user.first_name,
+          last_name: user.last_name,
+          name: "#{user.first_name} #{user.last_name}",
+          params: "#{user.first_name} #{user.last_name} ",
+          params_upcase: "#{user.first_name} #{user.last_name} ".upcase
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request improves the handling of the `params` option in the serializer by ensuring it defaults to an empty hash when not provided, preventing potential errors when accessing keys. The associated tests have been updated to reflect this change and to verify correct behavior when `params` is omitted.

**Serializer parameter handling improvements:**

* [`lib/bright_serializer/serializer.rb`](diffhunk://#diff-8908bd33a2b38f598eb014efe4cab90260ef715d46e03d91c4e19efab9ed4e5bL25-R25): Changed the initialization of `@params` to default to an empty hash if not provided, ensuring safe access to keys like `params[:suffix]`.

**Test updates for parameter handling:**

* [`spec/bright_serializer/serializer_params_spec.rb`](diffhunk://#diff-cca6ea9a8034b25a8fe8f14f9db2ac3bca74cdbf3f57fbdb8d0e84fd5c2a509cL18-R31): Updated attribute blocks and helper methods to access `params[:suffix]` instead of the entire `params` object, and changed test setup to pass `{ suffix: param }` as `params`.
* [`spec/bright_serializer/serializer_params_spec.rb`](diffhunk://#diff-cca6ea9a8034b25a8fe8f14f9db2ac3bca74cdbf3f57fbdb8d0e84fd5c2a509cR47-R62): Added a new context and test to ensure that when `params` is not passed, it defaults to an empty hash and does not raise errors.